### PR TITLE
Fix get_full_path with empty directory_path

### DIFF
--- a/libcpath/libcpath_path.c
+++ b/libcpath/libcpath_path.c
@@ -1350,7 +1350,7 @@ int libcpath_path_get_full_path(
 		}
 		current_directory_segment_index = current_directory_number_of_segments - 1;
 	}
-	if( libcsplit_narrow_split_string_get_number_of_segments(
+	if( path_split_string != NULL && libcsplit_narrow_split_string_get_number_of_segments(
 	     path_split_string,
 	     &path_number_of_segments,
 	     error ) != 1 )
@@ -2127,7 +2127,7 @@ int libcpath_path_get_full_path(
 		}
 		current_directory_segment_index = current_directory_number_of_segments - 1;
 	}
-	if( libcsplit_narrow_split_string_get_number_of_segments(
+	if( path_split_string != NULL && libcsplit_narrow_split_string_get_number_of_segments(
 	     path_split_string,
 	     &path_number_of_segments,
 	     error ) != 1 )
@@ -4916,7 +4916,7 @@ int libcpath_path_get_full_path_wide(
 		}
 		current_directory_segment_index = current_directory_number_of_segments - 1;
 	}
-	if( libcsplit_wide_split_string_get_number_of_segments(
+	if( path_split_string != NULL && libcsplit_wide_split_string_get_number_of_segments(
 	     path_split_string,
 	     &path_number_of_segments,
 	     error ) != 1 )
@@ -5693,7 +5693,7 @@ int libcpath_path_get_full_path_wide(
 		}
 		current_directory_segment_index = current_directory_number_of_segments - 1;
 	}
-	if( libcsplit_wide_split_string_get_number_of_segments(
+	if( path_split_string != NULL && libcsplit_wide_split_string_get_number_of_segments(
 	     path_split_string,
 	     &path_number_of_segments,
 	     error ) != 1 )


### PR DESCRIPTION
It is because on https://github.com/libyal/libcpath/blob/main/libcpath/libcpath_path.c#L1283 `path_directory_name_index` point to empty string. As result `path_split_string` is `NULL` (but `libcsplit_narrow_string_split` returned 1 https://github.com/libyal/libcsplit/blob/main/libcsplit/libcsplit_narrow_string.c#L97)
Some later trying to get number of segments: https://github.com/libyal/libcpath/blob/main/libcpath/libcpath_path.c#L2130
But as `path_split_string` is `NULL`, that it failed(https://github.com/libyal/libcsplit/blob/main/libcsplit/libcsplit_narrow_split_string.c#L352).
So need to check `path_split_string` on `NULL` before `libcsplit_narrow_split_string_get_number_of_segments`.
